### PR TITLE
Add GitHub Actions CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Most of the extension UI lives in the Team Explorer pane, which is available fro
 
 Official builds of this extension are available at the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=GitHub.GitHubExtensionforVisualStudio).
 
-[![Build Status](https://github-editor-tools.visualstudio.com/VisualStudio/_apis/build/status/github.VisualStudio?branchName=master)](https://github-editor-tools.visualstudio.com/VisualStudio/_build/latest?definitionId=10&branchName=master)
+![CI](https://github.com/github/visualstudio/workflows/CI/badge.svg)
 
 [![Follow GitHub for Visual Studio](https://img.shields.io/twitter/follow/GitHubVS.svg?style=social "Follow GitHubVS")](https://twitter.com/githubvs?ref_src=twsrc%5Etfw) [![Join the chat at https://gitter.im/github/VisualStudio](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/github/VisualStudio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
Replace the obsolete Azure Pipelines badge with GitHub Actions badge.